### PR TITLE
TRD-1749: Escape send queued when blocked on connection side

### DIFF
--- a/session.go
+++ b/session.go
@@ -351,23 +351,14 @@ func (s *session) persist(seqNum int, msgBytes []byte) error {
 }
 
 func (s *session) sendQueued() {
-	var (
-		sent         bool
-		indexBlocked int
-	)
-
 	for i, msgBytes := range s.toSend {
-		sent = s.sendBytes(msgBytes)
-		if !sent {
-			indexBlocked = i
-			break
+		if !s.sendBytes(msgBytes) {
+			s.toSend = s.toSend[i:]
+			s.notifyMessageOut()
+			return
 		}
 	}
-	if !sent {
-		s.toSend = s.toSend[indexBlocked:]
-		s.notifyMessageOut()
-		return
-	}
+
 	s.dropQueued()
 }
 

--- a/session.go
+++ b/session.go
@@ -352,18 +352,18 @@ func (s *session) persist(seqNum int, msgBytes []byte) error {
 
 func (s *session) sendQueued() {
 	var (
-		blocked      bool
+		sent         bool
 		indexBlocked int
 	)
 
 	for i, msgBytes := range s.toSend {
-		blocked = s.sendBytes(msgBytes)
-		if blocked {
+		sent = s.sendBytes(msgBytes)
+		if !sent {
 			indexBlocked = i
 			break
 		}
 	}
-	if blocked {
+	if !sent {
 		s.toSend = s.toSend[indexBlocked:]
 		s.notifyMessageOut()
 		return
@@ -390,11 +390,11 @@ func (s *session) sendBytes(msg []byte) bool {
 	}
 
 	select {
-	case <-time.After(5 * time.Millisecond):
-		return true
 	case s.messageOut <- msg:
 		s.log.OnOutgoing(msg)
 		s.stateTimer.Reset(s.HeartBtInt)
+		return true
+	default:
 		return false
 	}
 }

--- a/session.go
+++ b/session.go
@@ -235,12 +235,16 @@ func (s *session) queueForSend(msg *Message) error {
 
 	s.toSend = append(s.toSend, msgBytes)
 
+	s.notifyMessageOut()
+
+	return nil
+}
+
+func (s *session) notifyMessageOut() {
 	select {
 	case s.messageEvent <- true:
 	default:
 	}
-
-	return nil
 }
 
 // send will validate, persist, queue the message. If the session is logged on, send all messages in the queue.
@@ -347,10 +351,23 @@ func (s *session) persist(seqNum int, msgBytes []byte) error {
 }
 
 func (s *session) sendQueued() {
-	for _, msgBytes := range s.toSend {
-		s.sendBytes(msgBytes)
-	}
+	var (
+		blocked      bool
+		indexBlocked int
+	)
 
+	for i, msgBytes := range s.toSend {
+		blocked = s.sendBytes(msgBytes)
+		if blocked {
+			indexBlocked = i
+			break
+		}
+	}
+	if blocked {
+		s.toSend = s.toSend[indexBlocked:]
+		s.notifyMessageOut()
+		return
+	}
 	s.dropQueued()
 }
 
@@ -366,15 +383,20 @@ func (s *session) EnqueueBytesAndSend(msg []byte) {
 	s.sendQueued()
 }
 
-func (s *session) sendBytes(msg []byte) {
+func (s *session) sendBytes(msg []byte) bool {
 	if s.messageOut == nil {
 		s.log.OnEventf("Failed to send: disconnected")
-		return
+		return false
 	}
 
-	s.log.OnOutgoing(msg)
-	s.messageOut <- msg
-	s.stateTimer.Reset(s.HeartBtInt)
+	select {
+	case <-time.After(5 * time.Millisecond):
+		return true
+	case s.messageOut <- msg:
+		s.log.OnOutgoing(msg)
+		s.stateTimer.Reset(s.HeartBtInt)
+		return false
+	}
 }
 
 func (s *session) doTargetTooHigh(reject targetTooHigh) (nextState resendState, err error) {


### PR DESCRIPTION
## Issue 

### Observations
1. Very high lock contention on `session.sendMutex`
2. Random huge delays, after sending a message out getting the response taking to match time ~5s in some cases
3. Main [session loop](https://github.com/quickfixgo/quickfix/blob/3bf2b871219bd9921c206adf59585b920c133538/session.go#L801-L821)  is either sending a batch (and blocking until all messages in the batch are sent) or reading just ONE incoming message. 

So, if there are many messages in the slice `toSend`, session from our side is blocked until all the messages are sent. 
At the same time, if halfway (when half of the messages in `toSend` have been sent) the other side cannot accept more messages (maybe cause of a buffer overflow) in order to be unblocked, we need to consume some of the incoming messages, which with the current implementation cannot happen.

## Proposed solution
When sending queued messages, if any of the messages take more than 5ms to be sent, then we escape the `toSend` loop and leave the rest of the messages for the next session loop.
