### PR TITLE
Bug: For Logon/Logout/Resend/SequenceReset messages we should wait until sent

### DIFF
--- a/logon_state_test.go
+++ b/logon_state_test.go
@@ -333,7 +333,7 @@ func (s *LogonStateTestSuite) TestFixMsgInLogonSeqNumTooHigh() {
 	s.Require().Nil(err)
 	s.MessageType(string(msgTypeLogon), sentMessage)
 
-	s.session.sendQueued()
+	s.session.sendQueued(true)
 	s.MessageType(string(msgTypeResendRequest), s.MockApp.lastToAdmin)
 	s.FieldEquals(tagBeginSeqNo, 1, s.MockApp.lastToAdmin.Body)
 
@@ -373,7 +373,7 @@ func (s *LogonStateTestSuite) TestFixMsgInLogonSeqNumTooLow() {
 	s.Require().Nil(err)
 	s.MessageType(string(msgTypeLogout), sentMessage)
 
-	s.session.sendQueued()
+	s.session.sendQueued(true)
 	s.MessageType(string(msgTypeLogout), s.MockApp.lastToAdmin)
 	s.FieldEquals(tagText, "MsgSeqNum too low, expecting 2 but received 1", s.MockApp.lastToAdmin.Body)
 }

--- a/session_state.go
+++ b/session_state.go
@@ -105,7 +105,7 @@ func (sm *stateMachine) SendAppMessages(session *session) {
 	defer session.sendMutex.Unlock()
 
 	if session.IsLoggedOn() {
-		session.sendQueued()
+		session.sendQueued(false)
 	} else {
 		session.dropQueued()
 	}


### PR DESCRIPTION
## Issue 
When log on request was queued because cannot be send due to connection not ready,
Then it goes through the [main session loop](https://github.com/alpacahq/quickfix/blob/5dcde41f3e6e68e93e1fd381761cd9c7843aec43/session.go#L821-L841) which leads to [SendAppMessages](https://github.com/alpacahq/quickfix/blob/5dcde41f3e6e68e93e1fd381761cd9c7843aec43/session_state.go#L107-L111)

But, since session is not logged on yet because the message queued is the log on message, we drop the `toSend` queued messages so we lose the log on message itself.


## Proposed solution
For important messages like Logon/Logout/Resend/SequenceReset we block until sent. 