### PR TITLE
Make Initiator`s inbound channel buffered

### DIFF
--- a/initiator.go
+++ b/initiator.go
@@ -61,12 +61,10 @@ func (i *Initiator) Start() (err error) {
 			return
 		}
 
-		inChanCapacity := i.getInChanCapacity(sessionID, settings)
-
 		i.wg.Add(1)
 
 		go func(sessID SessionID) {
-			i.handleConnection(i.sessions[sessID], tlsConfig, dialer, inChanCapacity)
+			i.handleConnection(i.sessions[sessID], tlsConfig, dialer)
 			i.wg.Done()
 		}(sessionID)
 	}
@@ -143,8 +141,11 @@ func (i *Initiator) waitForReconnectInterval(reconnectInterval time.Duration) bo
 	return true
 }
 
-func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, dialer proxy.Dialer, inChanSize int) {
-	var wg sync.WaitGroup
+func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, dialer proxy.Dialer) {
+	var (
+		wg             sync.WaitGroup
+		inChanCapacity = i.getInChanCapacity(session.sessionID)
+	)
 	wg.Add(1)
 	go func() {
 		session.run()
@@ -192,7 +193,7 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 			netConn = tlsConn
 		}
 
-		msgIn = make(chan fixIn, inChanSize)
+		msgIn = make(chan fixIn, inChanCapacity)
 		msgOut = make(chan []byte)
 		if err := session.connect(msgIn, msgOut); err != nil {
 			session.log.OnEventf("Failed to initiate: %v", err)
@@ -224,13 +225,14 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 	}
 }
 
-func (i *Initiator) getInChanCapacity(sessionID SessionID, settings *SessionSettings) int {
-	if !settings.HasSetting(initiatorInChanCapacityConfig) {
+func (i *Initiator) getInChanCapacity(sessionID SessionID) int {
+	if !i.settings.globalSettings.HasSetting(initiatorInChanCapacityConfig) {
 		return 0
 	}
 
-	inChanCapacityStr, err := settings.Setting(initiatorInChanCapacityConfig)
+	inChanCapacityStr, err := i.settings.globalSettings.Setting(initiatorInChanCapacityConfig)
 	if err != nil {
+		// Zero channel size means unbuffered
 		i.sessions[sessionID].log.OnEventf("Failed to get setting %s, will default to 0: %v", initiatorInChanCapacityConfig, err)
 		return 0
 	}

--- a/initiator.go
+++ b/initiator.go
@@ -18,6 +18,7 @@ package quickfix
 import (
 	"bufio"
 	"crypto/tls"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -39,6 +40,11 @@ type Initiator struct {
 	sessionFactory
 }
 
+// note: Here we don't use "github.com/alpacahq/quickfix/config" to set the config "InitiatorInChanCapacity"
+// because we currently use "github.com/quickfixgo/quickfix/config" for the configs so it will break the dependencies
+// either way, the config can be passed through the SessionSettings map
+const initiatorInChanCapacityConfig = "InitiatorInChanCapacity"
+
 // Start Initiator.
 func (i *Initiator) Start() (err error) {
 	i.stopChan = make(chan interface{})
@@ -55,9 +61,12 @@ func (i *Initiator) Start() (err error) {
 			return
 		}
 
+		inChanCapacity := i.getInChanCapacity(sessionID, settings)
+
 		i.wg.Add(1)
+
 		go func(sessID SessionID) {
-			i.handleConnection(i.sessions[sessID], tlsConfig, dialer)
+			i.handleConnection(i.sessions[sessID], tlsConfig, dialer, inChanCapacity)
 			i.wg.Done()
 		}(sessionID)
 	}
@@ -134,7 +143,7 @@ func (i *Initiator) waitForReconnectInterval(reconnectInterval time.Duration) bo
 	return true
 }
 
-func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, dialer proxy.Dialer) {
+func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, dialer proxy.Dialer, inChanSize int) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -183,7 +192,7 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 			netConn = tlsConn
 		}
 
-		msgIn = make(chan fixIn)
+		msgIn = make(chan fixIn, inChanSize)
 		msgOut = make(chan []byte)
 		if err := session.connect(msgIn, msgOut); err != nil {
 			session.log.OnEventf("Failed to initiate: %v", err)
@@ -213,4 +222,24 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 			return
 		}
 	}
+}
+
+func (i *Initiator) getInChanCapacity(sessionID SessionID, settings *SessionSettings) int {
+	if !settings.HasSetting(initiatorInChanCapacityConfig) {
+		return 0
+	}
+
+	inChanCapacityStr, err := settings.Setting(initiatorInChanCapacityConfig)
+	if err != nil {
+		i.sessions[sessionID].log.OnEventf("Failed to get setting %s, will default to 0: %v", initiatorInChanCapacityConfig, err)
+		return 0
+	}
+
+	inChanCapacityVal, err := strconv.Atoi(inChanCapacityStr)
+	if err != nil {
+		i.sessions[sessionID].log.OnEventf("Invalid value for setting %s, must be a non-negative integer, will default to 0: %v", initiatorInChanCapacityConfig, err)
+		return 0
+	}
+
+	return inChanCapacityVal
 }

--- a/initiator.go
+++ b/initiator.go
@@ -236,7 +236,7 @@ func (i *Initiator) getInChanCapacity(sessionID SessionID, settings *SessionSett
 	}
 
 	inChanCapacityVal, err := strconv.Atoi(inChanCapacityStr)
-	if err != nil {
+	if err != nil || inChanCapacityVal < 0 {
 		i.sessions[sessionID].log.OnEventf("Invalid value for setting %s, must be a non-negative integer, will default to 0: %v", initiatorInChanCapacityConfig, err)
 		return 0
 	}

--- a/initiator.go
+++ b/initiator.go
@@ -62,7 +62,6 @@ func (i *Initiator) Start() (err error) {
 		}
 
 		i.wg.Add(1)
-
 		go func(sessID SessionID) {
 			i.handleConnection(i.sessions[sessID], tlsConfig, dialer)
 			i.wg.Done()

--- a/initiator.go
+++ b/initiator.go
@@ -238,7 +238,7 @@ func (i *Initiator) getInChanCapacity(sessionID SessionID) int {
 
 	inChanCapacityVal, err := strconv.Atoi(inChanCapacityStr)
 	if err != nil || inChanCapacityVal < 0 {
-		i.sessions[sessionID].log.OnEventf("Invalid value for setting %s, must be a non-negative integer, will default to 0: %v", initiatorInChanCapacityConfig, err)
+		i.sessions[sessionID].log.OnEventf("Invalid value for setting %s, must be a non-negative integer, will default to 0 (unbuffered): %v", initiatorInChanCapacityConfig, err)
 		return 0
 	}
 

--- a/session.go
+++ b/session.go
@@ -669,6 +669,20 @@ func (s *session) checkBeginString(msg *Message) MessageRejectError {
 	return nil
 }
 
+func (s *session) drainMessageIn() {
+	for {
+		select {
+		case fixInc, ok := <-s.messageIn:
+			if !ok {
+				return
+			}
+			s.Incoming(s, fixInc)
+		default:
+			return
+		}
+	}
+}
+
 func (s *session) doReject(msg *Message, rej MessageRejectError) error {
 	reply := msg.reverseRoute()
 
@@ -736,6 +750,9 @@ func (s *session) onDisconnect() {
 		s.messageOut = nil
 	}
 
+	// s.messageIn is buffered so we need to drain it before disconnection
+	s.drainMessageIn()
+	
 	s.messageIn = nil
 }
 

--- a/session.go
+++ b/session.go
@@ -670,6 +670,7 @@ func (s *session) checkBeginString(msg *Message) MessageRejectError {
 }
 
 func (s *session) drainMessageIn() {
+	s.log.OnEventf("Draining %d messages from inbound channel...", len(s.messageIn))
 	for {
 		select {
 		case fixInc, ok := <-s.messageIn:
@@ -752,7 +753,7 @@ func (s *session) onDisconnect() {
 
 	// s.messageIn is buffered so we need to drain it before disconnection
 	s.drainMessageIn()
-	
+
 	s.messageIn = nil
 }
 


### PR DESCRIPTION
We have observed slow consumption of FIX messages in the Initiator.

Since the outbound channel is buffered, the event loop is sending too many messages at once but reads incoming messages one by one. This creates an inconsistency between incoming consumption messages and outgoing production messages.

In this PR we resolve this issue by making the inbound channel buffered. So the Initiator can now read and write in a truly asynchronous way.

This change is feature flagged. Can be used by setting `InitiatorInChanCapacity` with an integer representing the capacity of the inbound channel to the session settings config.