### PR TITLE
Stop writeLoop flood after TCP dead-socket write errors

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -18,14 +18,27 @@ package quickfix
 import "io"
 
 func writeLoop(connection io.Writer, messageOut chan []byte, log Log) {
+	var writeFailed bool
 	for {
 		msg, ok := <-messageOut
 		if !ok {
 			return
 		}
 
+		// After the first write failure the peer socket is dead. Keep draining
+		// messageOut (without writing or re-logging) so the session goroutine
+		// is not blocked on send, while closing the connection so readLoop
+		// fails and triggers a clean disconnect that closes messageOut.
+		if writeFailed {
+			continue
+		}
+
 		if _, err := connection.Write(msg); err != nil {
 			log.OnEvent(err.Error())
+			writeFailed = true
+			if closer, ok := connection.(io.Closer); ok {
+				_ = closer.Close()
+			}
 		}
 	}
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,0 +1,97 @@
+package quickfix
+
+import (
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+type stubLog struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (l *stubLog) OnIncoming([]byte)           {}
+func (l *stubLog) OnOutgoing([]byte)           {}
+func (l *stubLog) OnEventf(string, ...interface{}) {}
+func (l *stubLog) OnEvent(s string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.events = append(l.events, s)
+}
+
+func (l *stubLog) eventCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.events)
+}
+
+type failWriter struct {
+	mu     sync.Mutex
+	writes int
+	closed bool
+}
+
+func (w *failWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.writes++
+	return 0, errors.New("write tcp: broken pipe")
+}
+
+func (w *failWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.closed = true
+	return nil
+}
+
+func (w *failWriter) writeCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writes
+}
+
+func (w *failWriter) wasClosed() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.closed
+}
+
+var _ io.WriteCloser = (*failWriter)(nil)
+
+func TestWriteLoopStopsWritingAfterBrokenPipe(t *testing.T) {
+	msgOut := make(chan []byte)
+	log := &stubLog{}
+	w := &failWriter{}
+
+	done := make(chan struct{})
+	go func() {
+		writeLoop(w, msgOut, log)
+		close(done)
+	}()
+
+	// Flood the write loop with messages after the socket is dead.
+	for i := 0; i < 50; i++ {
+		msgOut <- []byte("8=FIX.4.2|35=8|")
+	}
+	close(msgOut)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("writeLoop did not exit after messageOut was closed")
+	}
+
+	if got := w.writeCount(); got != 1 {
+		t.Fatalf("expected exactly 1 Write attempt after broken pipe, got %d", got)
+	}
+	if got := log.eventCount(); got != 1 {
+		t.Fatalf("expected exactly 1 broken-pipe log event, got %d", got)
+	}
+	if !w.wasClosed() {
+		t.Fatal("expected connection to be closed after write failure")
+	}
+}


### PR DESCRIPTION
## Summary
- `writeLoop` previously logged a write error and **kept writing** every remaining outbound FIX message to a dead TCP socket. Under load this produced thousands of `write: broken pipe` events per disconnect (seen on `fixgateway-btgt` acceptor in integration-v2).
- On the first write failure: log once, close the connection so `readLoop` triggers a clean session disconnect, and drain `messageOut` without further writes (avoids blocking the session send path / deadlock).
- Adds a unit test that floods 50 messages after a simulated broken pipe and asserts exactly one `Write` and one log event.

## Notes
- Branched from upstream `v0.9.6` (module path `github.com/quickfixgo/quickfix`) so fixgateway can `replace` against this commit without a raw `vendor/` edit.
- Base is `merge-latest-quickfix` (upstream-synced) rather than `master` (old `github.com/alpacahq/quickfix` module path). Reviewers may prefer rebasing onto `merge-latest-quickfix` tip; the behavioral patch is confined to `connection.go`.

## Test plan
- [x] `go test -run TestWriteLoopStopsWritingAfterBrokenPipe -count=1`
- [ ] Deploy via fixgateway replace and reproduce a client disconnect under load
- [ ] Confirm acceptor logs a single broken-pipe / write error event instead of a multi-thousand-line flood